### PR TITLE
Removed unnecessary namespace

### DIFF
--- a/node/libs/core/package.json
+++ b/node/libs/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dontcode/core",
-  "version": "0.1.21",
+  "version": "0.2.0",
   "private": false,
   "main": "index.js",
   "peerDependencies": {

--- a/node/libs/core/src/index.ts
+++ b/node/libs/core/src/index.ts
@@ -9,4 +9,6 @@ export * from './lib/plugin/command-provider-interface';
 export * from './lib/plugin/preview-handler';
 export * from './lib/plugin/plugin-module-interface';
 export * from './lib/test/dont-code-test-manager';
+export * from './lib/store/dont-code-store-manager';
+export * from './lib/store/dont-code-store-provider';
 export * from './lib/globals';

--- a/node/libs/core/src/lib/dontcode.spec.ts
+++ b/node/libs/core/src/lib/dontcode.spec.ts
@@ -1,5 +1,5 @@
 import { DontCodeCore } from "./dontcode";
-import { DontCode } from "./globals";
+import * as DontCode from "./globals";
 import PluginConfig = DontCode.PluginConfig;
 
 describe('dontcode', () => {

--- a/node/libs/core/src/lib/dontcode.ts
+++ b/node/libs/core/src/lib/dontcode.ts
@@ -1,18 +1,21 @@
-import { DontCode } from "./globals";
-import { DontCodeSchemaManager } from "./model/dont-code-schema-manager";
-import { DontCodePluginManager } from "./plugin/dont-code-plugin-manager";
-import { DontCodePreviewManager } from "./plugin/preview/dont-code-preview-manager";
+import * as DontCode from "./globals";
+import {DontCodeSchemaManager} from "./model/dont-code-schema-manager";
+import {DontCodePluginManager} from "./plugin/dont-code-plugin-manager";
+import {DontCodePreviewManager} from "./plugin/preview/dont-code-preview-manager";
+import {DontCodeStoreManager} from "./store/dont-code-store-manager";
 
 export class DontCodeCore implements DontCode.Core {
 
     protected schemaManager:DontCodeSchemaManager;
     protected pluginManager:DontCodePluginManager;
     protected previewManager:DontCodePreviewManager;
+    protected storeManager:DontCodeStoreManager;
 
     constructor() {
       this.schemaManager = new DontCodeSchemaManager();
       this.pluginManager = new DontCodePluginManager();
       this.previewManager = new DontCodePreviewManager();
+      this.storeManager = new DontCodeStoreManager();
     }
 
     registerPlugin(plugin: DontCode.Plugin): void {
@@ -34,5 +37,8 @@ export class DontCodeCore implements DontCode.Core {
       return this.previewManager;
     }
 
+    getStoreManager (): DontCodeStoreManager {
+      return this.storeManager;
+    }
 }
 

--- a/node/libs/core/src/lib/globals.ts
+++ b/node/libs/core/src/lib/globals.ts
@@ -1,16 +1,17 @@
 import { DontCodeCore } from "./dontcode";
 import { DontCodeSchemaManager } from "./model/dont-code-schema-manager";
 import { DontCodePreviewManager } from "./plugin/preview/dont-code-preview-manager";
-
-export namespace DontCode {
-  export var dtcde: DontCode.Core = new DontCodeCore();
+import { DontCodeStoreManager } from "./store/dont-code-store-manager";
 
   export interface Core {
     getSchemaUri (): string;
     registerPlugin (plugin:Plugin): void;
     getSchemaManager (): DontCodeSchemaManager;
     getPreviewManager (): DontCodePreviewManager;
+    getStoreManager (): DontCodeStoreManager;
   }
+
+  export const dtcde: Core = new DontCodeCore();
 
   export interface Plugin {
     getConfiguration (): PluginConfig ;
@@ -19,7 +20,7 @@ export namespace DontCode {
   /**
    * The typescript equivalent of the dont-code-schema.json
    */
-  export interface DontCodeSchema {
+  export interface DontCodeSchemaType {
     creation: {
       type: string,
       name: string,
@@ -81,6 +82,5 @@ export namespace DontCode {
       name
     }
   }
-}
 
 export {};

--- a/node/libs/core/src/lib/model/dont-code-schema-item.ts
+++ b/node/libs/core/src/lib/model/dont-code-schema-item.ts
@@ -1,4 +1,4 @@
-import { DontCode } from "../globals";
+import * as DontCode from "../globals";
 
 /**
  * Stores and manipulate the schema representing a dont-code application

--- a/node/libs/core/src/lib/model/dont-code-schema-manager.spec.ts
+++ b/node/libs/core/src/lib/model/dont-code-schema-manager.spec.ts
@@ -1,4 +1,4 @@
-import { DontCode } from "@dontcode/core";
+import * as DontCode from "@dontcode/core";
 import dtcde = DontCode.dtcde;
 import { DontCodeSchemaEnum, DontCodeSchemaObject, DontCodeSchemaRoot } from "./dont-code-schema-item";
 import PluginConfig = DontCode.PluginConfig;

--- a/node/libs/core/src/lib/model/dont-code-schema-manager.ts
+++ b/node/libs/core/src/lib/model/dont-code-schema-manager.ts
@@ -1,6 +1,6 @@
 import { DontCodeSchemaItem, DontCodeSchemaRef, DontCodeSchemaRoot } from "./dont-code-schema-item";
 import { DontCodeModelPointer, DontCodeSchema } from "./dont-code-schema";
-import { DontCode } from "../globals";
+import {PluginConfig} from "../globals";
 
 export class DontCodeSchemaManager {
   protected currentSchema:DontCodeSchemaRoot;
@@ -22,7 +22,7 @@ export class DontCodeSchemaManager {
     return new DontCodeSchemaRoot(readSchema);
   }
 
-  registerChanges(config: DontCode.PluginConfig) {
+  registerChanges(config: PluginConfig) {
     const pluginFullName = config.plugin.id+'-v'+config.plugin.version;
     if (config['schema-updates']) {
       const updates = config['schema-updates'];

--- a/node/libs/core/src/lib/plugin/dont-code-plugin-manager.ts
+++ b/node/libs/core/src/lib/plugin/dont-code-plugin-manager.ts
@@ -1,5 +1,5 @@
 import { DontCodeSchemaManager } from "../model/dont-code-schema-manager";
-import { DontCode } from "../globals";
+import * as DontCode from "../globals";
 import PluginConfig = DontCode.PluginConfig;
 import { DontCodePreviewManager } from "./preview/dont-code-preview-manager";
 

--- a/node/libs/core/src/lib/plugin/dont-code-plugin-manager.ts
+++ b/node/libs/core/src/lib/plugin/dont-code-plugin-manager.ts
@@ -7,9 +7,6 @@ export class DontCodePluginManager {
 
   protected plugins:Map<string,DontCode.Plugin>=new Map();
 
-  constructor() {
-  }
-
   registerPlugin(plugin: DontCode.Plugin, schemaManager: DontCodeSchemaManager, previewManager:DontCodePreviewManager ) {
     const config:PluginConfig = plugin.getConfiguration();
     const fullId = config.plugin.id+'-v'+config.plugin.version;

--- a/node/libs/core/src/lib/plugin/preview/dont-code-preview-manager.spec.ts
+++ b/node/libs/core/src/lib/plugin/preview/dont-code-preview-manager.spec.ts
@@ -1,5 +1,5 @@
 import { DontCodeCore } from "../../dontcode";
-import { DontCode } from "../../globals";
+import * as DontCode from "../../globals";
 import PluginConfig = DontCode.PluginConfig;
 
 describe('Preview Manager', () => {

--- a/node/libs/core/src/lib/plugin/preview/dont-code-preview-manager.ts
+++ b/node/libs/core/src/lib/plugin/preview/dont-code-preview-manager.ts
@@ -1,5 +1,5 @@
-import { DontCode, DontCodeSchemaItem } from "@dontcode/core";
-import PreviewHandlerConfig = DontCode.PreviewHandlerConfig;
+import { DontCodeSchemaItem, PreviewHandlerConfig } from "@dontcode/core";
+import * as DontCode from "@dontcode/core";
 
 export class DontCodePreviewManager {
   protected handlersPerLocations: Map<string, PreviewHandlerConfig[] >

--- a/node/libs/core/src/lib/store/dont-code-store-manager.ts
+++ b/node/libs/core/src/lib/store/dont-code-store-manager.ts
@@ -11,11 +11,11 @@ export class DontCodeStoreManager {
   }
 
 
-  get provider(): DontCodeStoreProvider {
+  getProvider(): DontCodeStoreProvider {
     return this._default;
   }
 
-  set provider(value: DontCodeStoreProvider) {
+  setProvider(value: DontCodeStoreProvider) {
     this._default = value;
   }
 

--- a/node/libs/core/src/lib/store/dont-code-store-manager.ts
+++ b/node/libs/core/src/lib/store/dont-code-store-manager.ts
@@ -1,0 +1,59 @@
+import { Observable } from 'rxjs';
+import {DontCodeStoreProvider} from "./dont-code-store-provider";
+
+export class DontCodeStoreManager {
+
+  private _default: DontCodeStoreProvider;
+
+
+  constructor(provider?:DontCodeStoreProvider) {
+    this._default = provider;
+  }
+
+
+  get provider(): DontCodeStoreProvider {
+    return this._default;
+  }
+
+  set provider(value: DontCodeStoreProvider) {
+    this._default = value;
+  }
+
+  storeEntity (position:string, entity:any) : Promise<boolean> {
+    return this._default.storeEntity(position, entity);
+  }
+
+  loadEntity (position:string, key: any) : Promise<any> {
+    return this._default.loadEntity(position, key);
+  }
+
+  deleteEntity (position:string, key:any): Promise<boolean> {
+    return this._default.deleteEntity(position, key);
+  }
+
+  searchEntities (position:string, ...criteria:DontCodeStoreCriteria[]): Observable<Array<any>> {
+    return this._default.searchEntities(position, ...criteria);
+  }
+
+}
+
+export enum DontCodeStoreCriteriaOperator {
+  EQUALS= '=',
+  LESS_THAN = '<',
+  LESS_THAN_EQUAL = '<='
+}
+
+export class DontCodeStoreCriteria {
+  name:string;
+  value: any;
+  operator: DontCodeStoreCriteriaOperator;
+
+
+  constructor(name: string, value: any, operator?: DontCodeStoreCriteriaOperator) {
+    this.name = name;
+    this.value = value;
+    this.operator = operator;
+    if (!this.operator)
+      this.operator = DontCodeStoreCriteriaOperator.EQUALS;
+  }
+}

--- a/node/libs/core/src/lib/store/dont-code-store-provider.ts
+++ b/node/libs/core/src/lib/store/dont-code-store-provider.ts
@@ -1,0 +1,18 @@
+import { Observable } from 'rxjs';
+import {DontCodeStoreCriteria} from "./dont-code-store-manager";
+
+/**
+ * The standard interface for any store provider
+ */
+export interface DontCodeStoreProvider {
+
+  storeEntity (position:string, entity:any) : Promise<boolean>;
+
+  loadEntity (position:string, key: any) : Promise<any>;
+
+  deleteEntity (position:string, key:any): Promise<boolean>;
+
+  searchEntities (position:string, ...criteria:DontCodeStoreCriteria[]): Observable<Array<any>>;
+
+}
+

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -12281,6 +12281,7 @@
           "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
           "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "isexe": "^2.0.0"
           }
@@ -12463,6 +12464,7 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
           "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }


### PR DESCRIPTION
Incompatible change, as we moved from typescript's namespace DontCode to ES2015 module names.
Change the
`import {DontCode} from "@dontcode/core";`
to
`import * as DontCode from "@dontcode/core";`

or even directly imports the needed class:
`import { DontCodeSchemaManager } from "@dontcode/core";`
